### PR TITLE
마크다운 코드블럭 관련 CSS 수정

### DIFF
--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -186,6 +186,8 @@
       background: #eee;
       border-radius: 4px;
       padding: 4px;
+      -webkit-box-decoration-break: clone;
+      box-decoration-break: clone;
     }
 
     details {


### PR DESCRIPTION
문서를 작성하던 도중 아래의 그림과 같이 첫 번째 줄을 제외한 다른 줄의 padding이 적용되지 않는 오류를 발견했습니다.
![image](https://user-images.githubusercontent.com/23614497/74590784-f3718700-5054-11ea-930f-f3254b982f09.png)
이 이슈와 관련한 [stackoverflow 포스트](https://stackoverflow.com/questions/34659853/how-to-apply-padding-to-every-line-in-multi-line-text)의 채택된 답변과 같이
```
-webkit-box-decoration-break: clone;
box-decoration-break: clone;
```
의 코드를 `/_sass/_post.scss` 파일의 code 태그에 해당하는 부분에 추가했습니다.